### PR TITLE
Ensure name and type are part of the exception's reason

### DIFF
--- a/Sources/SCInject/ContainerError.swift
+++ b/Sources/SCInject/ContainerError.swift
@@ -40,7 +40,7 @@ public struct ContainerError: Error {
     }
 
     static func raise(reason: String, type: String, name: String?) {
-        ContainerException.raise(reason: reason, type: type, name: nil)
+        ContainerException.raise(reason: reason, type: type, name: name)
     }
 
     // MARK: - Private

--- a/Sources/SCInjectObjc/ContainerException.m
+++ b/Sources/SCInjectObjc/ContainerException.m
@@ -18,18 +18,24 @@
 
 NSString* const CSContainerExceptionTypeKey = @"SCContainerExceptionTypeKey";
 NSString* const CSContainerExceptionNameKey = @"SCContainerExceptionNameKey";
+NSString* const CSContainerExceptionReasonKey = @"SCContainerExceptionReasonKey";
 
 @implementation ContainerException
 
 + (void)raiseWithReason:(NSString *)reason type:(NSString *)type name:(nullable NSString *)name {
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{
-        CSContainerExceptionTypeKey: type
+        CSContainerExceptionTypeKey: type,
+        CSContainerExceptionReasonKey: reason
     }];
+    NSMutableString *details = [[NSMutableString alloc] init];
+    [details appendFormat:@"TYPE=%@", type];
     if (name) {
         userInfo[CSContainerExceptionNameKey] = name;
+        [details appendFormat:@" NAME=%@", name];
     }
+
     @throw [NSException exceptionWithName:@"SCBasicObjc.Exception"
-                                   reason:reason
+                                   reason:[NSString stringWithFormat:@"%@ -- %@", reason, details]
                                  userInfo:userInfo];
 }
 
@@ -42,7 +48,8 @@ NSString* const CSContainerExceptionNameKey = @"SCContainerExceptionNameKey";
         if (error) {
             NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{
                 NSLocalizedDescriptionKey: exception.reason,
-                NSLocalizedFailureReasonErrorKey: exception.name,
+                NSLocalizedFailureErrorKey: exception.name,
+                CSContainerExceptionReasonKey: exception.userInfo[CSContainerExceptionReasonKey],
                 CSContainerExceptionTypeKey: exception.userInfo[CSContainerExceptionTypeKey]
             }];
             NSString *name = exception.userInfo[CSContainerExceptionNameKey];

--- a/Tests/SCInject/ContainerTests.swift
+++ b/Tests/SCInject/ContainerTests.swift
@@ -102,7 +102,7 @@ final class ContainerTests: XCTestCase {
         XCTAssertNoThrow(try container.validate())
     }
 
-    func testValidate_missingNamedType() {
+    func testValidate_missingNamedType() throws {
         // Given
         let second: RegistrationName = .init(rawValue: "second")
         let container = DefaultContainer()
@@ -116,9 +116,9 @@ final class ContainerTests: XCTestCase {
         // When / Then
         XCTAssertThrowsError(try container.validate()) { error in
             let error = error as? ContainerError
-            XCTAssertEqual(error?.reason, "Failed to resolve given type")
+            XCTAssertEqual(error?.reason, "Failed to resolve given type -- TYPE=TestClass1 NAME=second")
             XCTAssertEqual(error?.type, "TestClass1")
-            XCTAssertNil(error?.name)
+            XCTAssertEqual(error?.name, second.rawValue)
         }
     }
 }


### PR DESCRIPTION
Ensures the exceptions thrown when the dependency cannot be found includes the type and the name of the dependency.

Test Plan:
- Ensure all CI checks pass